### PR TITLE
update dependencies

### DIFF
--- a/reactive-banana-sdl2.cabal
+++ b/reactive-banana-sdl2.cabal
@@ -20,8 +20,8 @@ library
                      , Reactive.Banana.SDL2.Types
                      , Reactive.Banana.SDL2.Util
   build-depends:       base             >= 4.7      && < 5
-                     , reactive-banana  >= 1.1.0    && < 1.2.0
-                     , sdl2             >= 2.1.0    && < 2.2.0
+                     , reactive-banana  >= 1.1.0    && < 1.3.0
+                     , sdl2             >= 2.1.0    && < 2.5.0
   default-language:    Haskell2010
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.17
+resolver: lts-11.9
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -9,8 +9,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- reactive-banana-1.1.0.0
-- sdl2-2.1.1
+- reactive-banana-1.2.0.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
The newest versions of reactive-banana and sdl2 work with this package. Updating the dependencies also makes this package fit more easily in dependency trees.